### PR TITLE
Add test status badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel:
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cylc-textmate-grammar
 
+![test](https://github.com/cylc/cylc-textmate-grammar/workflows/test/badge.svg?branch=master&event=push)
+
 This repository provides a TextMate grammar for Cylc workflow configuration (`suite.rc`) files, enabling syntax highlighting and other features.
 
 `cylc.tmLanguage.json` is the grammar file used by plugins for editors:


### PR DESCRIPTION
- The test workflow now also runs when a commit is pushed to master (including PR merge).
- The badge only shows the status of test workflow run on push to master