### PR TITLE
Add default file associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides a TextMate grammar for Cylc workflow configuration (`su
 
 `cylc.tmLanguage.json` is the grammar file used by plugins for editors:
 - VSCode - [cylc/vscode-cylc](https://github.com/cylc/vscode-cylc)
-- Atom (in future)
+- Atom - [cylc/language-cylc](https://github.com/cylc/language-cylc)
 
 It is also used to build a TextMate bundle at [cylc/Cylc.tmLanguage](https://github.com/cylc/Cylc.tmbundle/) which is compatible with:
 - TextMate

--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -90,7 +90,7 @@
                     "contentName": "meta.graph-section.cylc",
                     "comment": "Cylc 8 graph syntax",
                     "begin": "\\[{2}[\\t ]*graph[\\t ]*\\]{2}",
-                    "end": "(?=^[\t ]*\\[)",
+                    "end": "(?=^[\\t ]*\\[)",
                     "beginCaptures": {
                         "0": {
                             "patterns": [

--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -1,6 +1,13 @@
 {
     "scopeName": "source.cylc",
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "fileTypes": [
+        "suite.rc",
+        "suite.rc.processed",
+        "cylc",
+        "flow.rc",
+        "flow-tests.rc"
+    ],
     "name": "cylc",
     "patterns": [
         {

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -787,6 +787,7 @@ class Jinja2Comment {
 exports.tmLanguage = {
     scopeName: 'source.cylc',
     $schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json',
+    fileTypes: ['suite.rc', 'suite.rc.processed', 'cylc', 'flow.rc', 'flow-tests.rc'],
     name: 'cylc',
     patterns: [
         {include: '#comments'},

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -251,7 +251,7 @@ class GraphSection8 extends GraphSection7 {
             contentName: 'meta.graph-section.cylc',
             comment: 'Cylc 8 graph syntax',
             begin: `\\[{2}[\\t ]*graph[\\t ]*\\]{2}`,
-            end: `(?=^[\t ]*\\[)`,
+            end: `(?=^[\\t ]*\\[)`,
             beginCaptures: {
                 0: {
                     patterns: [


### PR DESCRIPTION
For Atom and the tmBundle editors.

VScode ignores this and has its own rules