### PR TITLE
Update setup node to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2.1.0
     
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v2
       with:
         node-version: '10.x'
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: '10.x'
+        node-version: '14.16.x'
     
     - name: Install (dev) dependencies
       run: npm install


### PR DESCRIPTION
There is another open PR for a dependabot security update. That PR is failing in GH actions in the setup-node task. I believe updating to the latest setup-node action should fix that :+1: 

Also bumped node to use the LTS version - https://nodejs.org/en/download/