### PR TITLE
Jinja2 in Cylc comment; improve optional outputs recognition

### DIFF
--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -497,12 +497,18 @@
             "patterns": [
                 {
                     "name": "comment.line.cylc",
-                    "match": "(#).*",
-                    "captures": {
-                        "1": {
+                    "begin": "#",
+                    "end": "(?=[\\n\\r])",
+                    "beginCaptures": {
+                        "0": {
                             "name": "punctuation.definition.comment.cylc"
                         }
-                    }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#jinja2"
+                        }
+                    ]
                 }
             ]
         },

--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -276,7 +276,7 @@
                 },
                 {
                     "name": "keyword.other.optional-output.cylc",
-                    "match": "(?<=\\w\\s*)\\?(?=[\\s=])"
+                    "match": "(?<=(\\b\\w[\\w\\+\\-@%]*|((:)([\\w\\-]+))|<.*>) *)\\?(?![:\\w])"
                 },
                 {
                     "name": "variable.other.xtrigger.cylc",

--- a/reference-files/flow.cylc
+++ b/reference-files/flow.cylc
@@ -85,12 +85,12 @@ R1 = """
     (foo & bar) =>
 !qux
     foo => !foo &!bar =>!pub
-    foo? => bar:fail? => baz?=> pub
-    # ! foo or foo!bar should NOT be highlighted:
+    foo? => bar:fail? => baz?=> pub<x>?
+    # ! or ? should NOT be highlighted:
     ! foo
     foo!bar
-    # ?foo or foo?:fail should NOT be highlighted:
-    ?foo => bar?:fail => baz:?fail
+    ?foo =>?bar
+    foo?:bar
 
     # SYNTAX: 2.4
     # text inside <> should be highlighted

--- a/reference-files/flow_jinja2.cylc
+++ b/reference-files/flow_jinja2.cylc
@@ -62,6 +62,8 @@ a = {{ b_b | c.d('1', "2", 3) }}
 {# foo #}  # foo
 {% foo %}  # foo
 {{ foo }}  # foo
+# Jinja2 in a comment should not display as commented out (note: can depend on theme)
+# foo {% foo %}
 
 # SYNTAX 3./1.3
 # tasks and deps outside of the templating code should display as normal

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -86,10 +86,15 @@ class LineComment {
     constructor() {
         this.pattern = {
             name: 'comment.line.cylc',
-            match: '(#).*',
-            captures: {
-                1: {name: 'punctuation.definition.comment.cylc'}
-            }
+            begin: '#',
+            end: '(?=[\\n\\r])',
+            beginCaptures: {
+                0: {name: 'punctuation.definition.comment.cylc'}
+            },
+            patterns: [
+                // Jinja2 in comment still gets executed at parse-time
+                {include: '#jinja2'}
+            ]
         };
     }
 }

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -292,6 +292,7 @@ class GraphSection8 extends GraphSection7 {
 class GraphSyntax {
     constructor() {
         const task = new Task();
+        const qualifier = new TaskQualifier();
         this.patterns = [
             {include: '#comments'},
             {include: '#parameterizations'},
@@ -329,7 +330,11 @@ class GraphSyntax {
             },
             {
                 name: 'keyword.other.optional-output.cylc',
-                match: `(?<=\\w\\s*)\\?(?=[\\s=])`,
+                match: [
+                    `(?<=(${task.regex}|${qualifier.regex}|<.*>) *)`,
+                    `\\?`,
+                    `(?![:\\w])`,
+                ].join('')
             },
             {
                 name: 'variable.other.xtrigger.cylc',

--- a/tests/2.3_graph_operators.cylc
+++ b/tests/2.3_graph_operators.cylc
@@ -36,9 +36,11 @@ graph = """
 
 ## Optional outputs
     foo? => bar:fail? => baz?=> pub ?
-#      ^            ^       ^       ^  keyword.other.optional-output.cylc
+#      ^            ^       ^       ^ keyword.other.optional-output.cylc
+    foo?&bar => baz<x>? => pub:custom-2?
+#      ^              ^                ^ keyword.other.optional-output.cylc
 
 ## Invalid optional outputs
-    ?foo => bar?:fail
-#   ^          ^      - keyword.other.optional-output.cylc
+    ?foo =>?bar => baz?pub => qux?:fail
+#   ^      ^          ^          ^      - keyword.other.optional-output.cylc
 """

--- a/tests/3.2-3_jinja.cylc
+++ b/tests/3.2-3_jinja.cylc
@@ -13,9 +13,8 @@
     {{ foo_bar }}  {{ foo | bar(1, 2, 3) }}
 #   ^^                                      punctuation.definition.template-expression.begin.jinja
 #              ^^                           punctuation.definition.template-expression.end.jinja
-#   ^^^^^^^^^^^^^                           meta.embedded.block.jinja source.jinja
+#   ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.block.jinja source.jinja
 #                ^^                         - meta.embedded.block.jinja source.jinja
-#                  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.block.jinja source.jinja
 
     {% set foo = {"1": 2, "3", {"1": 2}} %}
 #                                     ^^    - punctuation.definition.template-expression.end.jinja
@@ -47,9 +46,8 @@
 
 ## Whitespace control
     {%+ foo -%} {%- foo %}
-#   ^^^                    punctuation.definition.template-expression.begin.jinja
+#   ^^^         ^^^        punctuation.definition.template-expression.begin.jinja
 #           ^^^            punctuation.definition.template-expression.end.jinja
-#               ^^^        punctuation.definition.template-expression.begin.jinja
 
 
 ## Inside Cylc syntax patterns
@@ -81,17 +79,13 @@ graph = """
 #            ^^^^^^^ meta.embedded.block.jinja source.jinja
 
     foo<{{ a }}> & bar<x={{ b }}>
-#       ^^^^^^^                   meta.embedded.block.jinja source.jinja
-#                         ^^^^^^  meta.embedded.block.jinja source.jinja
+#       ^^^^^^^          ^^^^^^^  meta.embedded.block.jinja source.jinja
 
     foo:{{ a }} & bar:custom_{{ b }} & {{ c }}:fail
-#       ^^^^^^^                                     meta.embedded.block.jinja source.jinja
-#                            ^^^^^^^                meta.embedded.block.jinja source.jinja
-#                                      ^^^^^^^      meta.embedded.block.jinja source.jinja
+#       ^^^^^^^              ^^^^^^^   ^^^^^^^      meta.embedded.block.jinja source.jinja
 
     foo[{{ a }}] & bar[-P{{ b }}]
-#       ^^^^^^^                   meta.embedded.block.jinja source.jinja
-#                        ^^^^^^^  meta.embedded.block.jinja source.jinja
+#       ^^^^^^^          ^^^^^^^  meta.embedded.block.jinja source.jinja
 """
 
 [[graph]]

--- a/tests/3.2-3_jinja.cylc
+++ b/tests/3.2-3_jinja.cylc
@@ -97,3 +97,9 @@ graph = """
 [[graph]]
     {{ a }} = foo => bar
 #   ^^^^^^^              meta.embedded.block.jinja source.jinja
+
+[scheduler]
+## Inside a Cylc comment (it still gets executed at parse-time)
+    # blah {% set x = 14 %} blah {{ x }}
+#   ^^^^^^^                ^^^^^^        comment.line.cylc
+#          ^^^^^^^^^^^^^^^^      ^^^^^^^ meta.embedded.block.jinja source.jinja


### PR DESCRIPTION
Closes #32 

> ```ini
> #!jinja2
> # {% set x = 12 %}
> ```
> 
> Even though the Jinja2 statement is in a Cylc comment, it still gets executed at parse-time. So it should not be tokenised as a comment.

Follow-up to #35 - improve optional outputs regex

