### PR TITLE
Remove variable-length lookbehinds

### DIFF
--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -231,8 +231,65 @@
                     "include": "#jinja2"
                 },
                 {
-                    "name": "meta.variable.task.cylc",
-                    "match": "\\b\\w[\\w\\+\\-@%]*"
+                    "match": "(\\b\\w[\\w\\+\\-@%]*)((\\[)([^\\]]+)(\\]))?((:)([\\w\\-]+))?\\s*(\\?(?![:\\w]))?",
+                    "captures": {
+                        "1": {
+                            "name": "meta.variable.task.cylc"
+                        },
+                        "2": {
+                            "name": "meta.annotation.inter-cycle.cylc"
+                        },
+                        "3": {
+                            "name": "punctuation.section.brackets.begin.cylc"
+                        },
+                        "4": {
+                            "name": "meta.annotation.inter-cycle.cylc",
+                            "patterns": [
+                                {
+                                    "include": "#jinja2"
+                                },
+                                {
+                                    "include": "#intervals"
+                                },
+                                {
+                                    "include": "#isodatetimes"
+                                },
+                                {
+                                    "comment": "Initial cycle point",
+                                    "match": "\\^",
+                                    "captures": {
+                                        "0": {
+                                            "name": "constant.language.cycle-point.cylc"
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "keyword.operator.arithmetic.cylc",
+                                    "match": "[\\+\\-]"
+                                },
+                                {
+                                    "name": "constant.numeric.integer-point.cylc",
+                                    "comment": "Integer as long as it isn't adjacent to a letter",
+                                    "match": "\\b\\d+\\b"
+                                }
+                            ]
+                        },
+                        "5": {
+                            "name": "punctuation.section.brackets.end.cylc"
+                        },
+                        "6": {
+                            "name": "meta.annotation.qualifier.cylc"
+                        },
+                        "7": {
+                            "name": "punctuation.definition.annotation.cylc"
+                        },
+                        "8": {
+                            "name": "variable.annotation.cylc"
+                        },
+                        "9": {
+                            "name": "keyword.other.optional-output.cylc"
+                        }
+                    }
                 },
                 {
                     "name": "keyword.control.trigger.cylc",
@@ -275,10 +332,6 @@
                     }
                 },
                 {
-                    "name": "keyword.other.optional-output.cylc",
-                    "match": "(?<=(\\b\\w[\\w\\+\\-@%]*|((:)([\\w\\-]+))|<.*>) *)\\?(?![:\\w])"
-                },
-                {
                     "name": "variable.other.xtrigger.cylc",
                     "match": "(@)[\\w\\-]+",
                     "captures": {
@@ -290,66 +343,6 @@
                 {
                     "name": "constant.character.escape.continuation.cylc",
                     "match": "\\\\"
-                },
-                {
-                    "comment": "e.g. foo:fail => bar",
-                    "match": "(?<!^|[\\s:])((:)([\\w\\-]+))",
-                    "captures": {
-                        "1": {
-                            "name": "meta.annotation.qualifier.cylc"
-                        },
-                        "2": {
-                            "name": "punctuation.definition.annotation.cylc"
-                        },
-                        "3": {
-                            "name": "variable.annotation.cylc"
-                        }
-                    }
-                },
-                {
-                    "name": "meta.annotation.inter-cycle.cylc",
-                    "comment": "e.g. foo[-P1]",
-                    "begin": "(?<=\\S)\\[",
-                    "end": "\\]",
-                    "beginCaptures": {
-                        "0": {
-                            "name": "punctuation.section.brackets.begin.cylc"
-                        }
-                    },
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.section.brackets.end.cylc"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#jinja2"
-                        },
-                        {
-                            "include": "#intervals"
-                        },
-                        {
-                            "include": "#isodatetimes"
-                        },
-                        {
-                            "comment": "If 1st char is ^ (allowing for spaces)",
-                            "match": "\\G[\\t ]*(\\^)",
-                            "captures": {
-                                "1": {
-                                    "name": "constant.language.cycle-point.cylc"
-                                }
-                            }
-                        },
-                        {
-                            "name": "keyword.operator.arithmetic.cylc",
-                            "match": "[\\+\\-]"
-                        },
-                        {
-                            "name": "constant.numeric.integer-point.cylc",
-                            "comment": "Integer as long as it isn't adjacent to a letter",
-                            "match": "\\b\\d+\\b"
-                        }
-                    ]
                 }
             ]
         },
@@ -517,15 +510,68 @@
                 {
                     "name": "meta.annotation.parameterization.cylc",
                     "begin": "<",
-                    "end": ">",
+                    "end": "(>)((\\[)([^\\]]+)(\\]))?((:)([\\w\\-]+))?\\s*(\\?(?![:\\w]))?",
                     "beginCaptures": {
                         "0": {
                             "name": "punctuation.definition.annotation.begin.cylc"
                         }
                     },
                     "endCaptures": {
-                        "0": {
+                        "1": {
                             "name": "punctuation.definition.annotation.end.cylc"
+                        },
+                        "2": {
+                            "name": "meta.annotation.inter-cycle.cylc"
+                        },
+                        "3": {
+                            "name": "punctuation.section.brackets.begin.cylc"
+                        },
+                        "4": {
+                            "name": "meta.annotation.inter-cycle.cylc",
+                            "patterns": [
+                                {
+                                    "include": "#jinja2"
+                                },
+                                {
+                                    "include": "#intervals"
+                                },
+                                {
+                                    "include": "#isodatetimes"
+                                },
+                                {
+                                    "comment": "Initial cycle point",
+                                    "match": "\\^",
+                                    "captures": {
+                                        "0": {
+                                            "name": "constant.language.cycle-point.cylc"
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "keyword.operator.arithmetic.cylc",
+                                    "match": "[\\+\\-]"
+                                },
+                                {
+                                    "name": "constant.numeric.integer-point.cylc",
+                                    "comment": "Integer as long as it isn't adjacent to a letter",
+                                    "match": "\\b\\d+\\b"
+                                }
+                            ]
+                        },
+                        "5": {
+                            "name": "punctuation.section.brackets.end.cylc"
+                        },
+                        "6": {
+                            "name": "meta.annotation.qualifier.cylc"
+                        },
+                        "7": {
+                            "name": "punctuation.definition.annotation.cylc"
+                        },
+                        "8": {
+                            "name": "variable.annotation.cylc"
+                        },
+                        "9": {
+                            "name": "keyword.other.optional-output.cylc"
                         }
                     },
                     "patterns": [
@@ -556,7 +602,7 @@
                                     }
                                 },
                                 {
-                                    "comment": "e.g. foo:fail => bar",
+                                    "comment": "e.g. foo:fail",
                                     "match": "(?<!^|[\\s:])((:)([\\w\\-]+))",
                                     "captures": {
                                         "1": {

--- a/tests/2.10_inter_cycle_deps.cylc
+++ b/tests/2.10_inter_cycle_deps.cylc
@@ -5,28 +5,22 @@ graph = """
 
 ## Integer intervals
     foo[P1] & bar[-P1]
-#      ^               punctuation.section.brackets.begin.cylc
-#       ^^             constant.numeric.interval.integer.cylc
-#         ^            punctuation.section.brackets.end.cylc
-#      ^^^^            meta.annotation.inter-cycle.cylc
+#      ^         ^     punctuation.section.brackets.begin.cylc
+#       ^^         ^^  constant.numeric.interval.integer.cylc
+#         ^          ^ punctuation.section.brackets.end.cylc
+#      ^^^^      ^^^^  meta.annotation.inter-cycle.cylc
 #                 ^    keyword.operator.arithmetic.cylc
-#                ^^^^  meta.annotation.inter-cycle.cylc
 
 ## ISO 8601 intervals
     foo[P1D] & bar[-P1D]
-#       ^^^              constant.numeric.interval.iso.cylc
+#       ^^^         ^^^  constant.numeric.interval.iso.cylc
 #                  ^     keyword.operator.arithmetic.cylc
-#                   ^^^  constant.numeric.interval.iso.cylc
     foo[P1DT1M] & bar[PT1M] & pub[P1Y1M1DT1H1M1S] & qux[P1W]
-#       ^^^^^^                                               constant.numeric.interval.iso.cylc
-#                     ^^^^                                   constant.numeric.interval.iso.cylc
-#                                 ^^^^^^^^^^^^^^             constant.numeric.interval.iso.cylc
-#                                                       ^^^  constant.numeric.interval.iso.cylc
+#       ^^^^^^        ^^^^        ^^^^^^^^^^^^^^        ^^^  constant.numeric.interval.iso.cylc
 
 ## Integer points
     foo[123] & bar[-12]
-#       ^^^             constant.numeric.integer-point.cylc
-#                   ^^  constant.numeric.integer-point.cylc
+#       ^^^         ^^  constant.numeric.integer-point.cylc
 
 ## ISO 8601 points (long)
     foo[2000-01-01T00:00:00-11:30]
@@ -35,26 +29,19 @@ graph = """
 #                          ^       punctuation.definition.timezone.cylc
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^  constant.numeric.isodatetime.long.cylc
     foo[2000-01-01T00:00Z] & foo[2000-01-01T00+05]
-#                       ^                          punctuation.definition.timezone.cylc
-#       ^^^^^^^^^^^^^^^^^                          constant.numeric.isodatetime.long.cylc
-#                                             ^    punctuation.definition.timezone.cylc
-#                                ^^^^^^^^^^^^^^^^  constant.numeric.isodatetime.long.cylc
+#                       ^                     ^    punctuation.definition.timezone.cylc
+#       ^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^  constant.numeric.isodatetime.long.cylc
 
     foo[2000-01-01] & foo[2000-00] & foo[2000]
-#       ^^^^^^^^^^                             constant.numeric.isodatetime.long.cylc
-#                         ^^^^^^^              constant.numeric.isodatetime.long.cylc
-#                                        ^^^^  constant.numeric.isodatetime.long.cylc
+#       ^^^^^^^^^^        ^^^^^^^        ^^^^  constant.numeric.isodatetime.long.cylc
 
 ## ISO 8601 points (short)
     foo[20051201T0215+0530] & foo[20051201T123000Z]
-#                    ^                              punctuation.definition.timezone.cylc
-#       ^^^^^^^^^^^^^^^^^^                          constant.numeric.isodatetime.short.cylc
-#                                                ^  punctuation.definition.timezone.cylc
-#                                 ^^^^^^^^^^^^^^^^  constant.numeric.isodatetime.short.cylc
+#                    ^                           ^  punctuation.definition.timezone.cylc
+#       ^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^  constant.numeric.isodatetime.short.cylc
     foo[20000000T00-11] & foo[20000000T0000]
 #                  ^                         punctuation.definition.timezone.cylc
-#       ^^^^^^^^^^^^^^                       constant.numeric.isodatetime.short.cylc
-#                             ^^^^^^^^^^^^^  constant.numeric.isodatetime.short.cylc
+#       ^^^^^^^^^^^^^^        ^^^^^^^^^^^^^  constant.numeric.isodatetime.short.cylc
 
 ## Bultins
     foo[^]
@@ -63,36 +50,23 @@ graph = """
 
 ## Arithmetic
     foo[^+P1D] & foo[20000101T0000+P1D] & foo[2+P1]
-#        ^                                          keyword.operator.arithmetic.cylc
-#      ^^^^^^^                                      meta.annotation.inter-cycle.cylc
-#                                 ^                 keyword.operator.arithmetic.cylc
-#                   ^^^^^^^^^^^^^^^^^^^             meta.annotation.inter-cycle.cylc
-#                                              ^    keyword.operator.arithmetic.cylc
+#        ^                        ^            ^    keyword.operator.arithmetic.cylc
+#      ^^^^^^^      ^^^^^^^^^^^^^^^^^^^             meta.annotation.inter-cycle.cylc
 
 ## Illegal intervals
     foo[P1H]
 #       ^^^  invalid.illegal.interval.cylc
     foo[P1D1Y] & foo[PT1M1H]
-#       ^^^^^                - constant.numeric.interval.iso.cylc
-#                    ^^^^^^  - constant.numeric.interval.iso.cylc
+#       ^^^^^        ^^^^^^  - constant.numeric.interval.iso.cylc
     foo[P] & foo[PT]
-#       ^            - constant.numeric.interval.integer.cylc constant.numeric.interval.iso.cylc
-#                ^^  - constant.numeric.interval.integer.cylc constant.numeric.interval.iso.cylc
+#       ^        ^^  - constant.numeric.interval.integer.cylc constant.numeric.interval.iso.cylc
 
 ## Illegal ISO points
     foo[200T00] & foo[2000T00Z] & foo[2000T00-01] & foo[200012T00]
-#       ^^^^^^                                                     invalid.illegal.isodatetime.cylc
-#                     ^^^^^^^^                                     invalid.illegal.isodatetime.cylc
-#                                     ^^^^^^^                      invalid.illegal.isodatetime.cylc
-#                                                       ^^^^^^^^^  invalid.illegal.isodatetime.cylc
+#       ^^^^^^        ^^^^^^^^        ^^^^^^^           ^^^^^^^^^  invalid.illegal.isodatetime.cylc
     foo[2000-01-01T0000] & foo[20000101T0000+10:00] & foo[20000101T00:00]
-#       ^^^^^^^^^^^^^^^                                                   invalid.illegal.isodatetime.cylc
-#                              ^^^^^^^^^^^^^^^^^^^                        invalid.illegal.isodatetime.cylc
-#                                                         ^^^^^^^^^^^^^^  invalid.illegal.isodatetime.cylc
+#       ^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^  invalid.illegal.isodatetime.cylc
     foo[01-01T00] & foo[01T00] & foo[T00] & foo[T-00]
-#       ^^^^^^^^                                      - constant.numeric.isodatetime.long.cylc constant.numeric.isodatetime.short.cylc
-#                       ^^^^^                         - constant.numeric.isodatetime.long.cylc constant.numeric.isodatetime.short.cylc
-#                                    ^^^              - constant.numeric.isodatetime.long.cylc constant.numeric.isodatetime.short.cylc
-#                                               ^^^^  - constant.numeric.isodatetime.long.cylc constant.numeric.isodatetime.short.cylc
+#       ^^^^^^^^        ^^^^^        ^^^        ^^^^  - constant.numeric.isodatetime.long.cylc constant.numeric.isodatetime.short.cylc
 
 """

--- a/tests/2.6-8_params.cylc
+++ b/tests/2.6-8_params.cylc
@@ -4,37 +4,30 @@
 graph = """
 
     <x> => bar<y>
-#   ^             punctuation.definition.annotation.begin.cylc
-#    ^            variable.parameter.cylc
-#     ^           punctuation.definition.annotation.end.cylc
-#   ^^^           meta.annotation.parameterization.cylc
-#             ^^^ meta.annotation.parameterization.cylc
+#   ^         ^   punctuation.definition.annotation.begin.cylc
+#    ^         ^  variable.parameter.cylc
+#     ^         ^ punctuation.definition.annotation.end.cylc
+#   ^^^       ^^^ meta.annotation.parameterization.cylc
 
 ## With operators & numbers
     <x-1> => <x + 1>
-#    ^               variable.parameter.cylc
-#     ^              keyword.operator.arithmetic.cylc
-#      ^             constant.numeric.cylc
-#   ^^^^^            meta.annotation.parameterization.cylc
-#             ^      variable.parameter.cylc
-#               ^    keyword.operator.arithmetic.cylc
-#                 ^  constant.numeric.cylc
-#            ^^^^^^^ meta.annotation.parameterization.cylc
+#    ^        ^      variable.parameter.cylc
+#     ^         ^    keyword.operator.arithmetic.cylc
+#      ^          ^  constant.numeric.cylc
+#   ^^^^^    ^^^^^^^ meta.annotation.parameterization.cylc
 
 ## With assignment
     a<x=1> => a<x = bar>
-#     ^                  variable.parameter.cylc
-#      ^                 keyword.operator.assignment.cylc
+#     ^         ^        variable.parameter.cylc
+#      ^          ^      keyword.operator.assignment.cylc
 #       ^                constant.numeric.cylc
-#    ^^^^^               meta.annotation.parameterization.cylc
-#               ^        variable.parameter.cylc
-#                 ^      keyword.operator.assignment.cylc
 #                   ^^^  variable.other.cylc
+#    ^^^^^     ^^^^^^^^^ meta.annotation.parameterization.cylc
 
 ## Multiple params
     a<x=bar, y = 2> => a<baz,4>
-#          ^                    punctuation.separator.parameter.cylc
-#            ^                  variable.parameter.cylc
+#          ^                ^   punctuation.separator.parameter.cylc
+#            ^           ^^^ ^  variable.parameter.cylc
 #              ^                keyword.operator.assignment.cylc
 #                ^              constant.numeric.cylc
 #                           ^   punctuation.separator.parameter.cylc
@@ -46,8 +39,7 @@ graph = """
 #      ^         punctuation.definition.annotation.begin.cylc
 #              ^ punctuation.definition.annotation.end.cylc
     <x_{{ a }}_y>
-#    ^^                                       variable.parameter.cylc
-#             ^^                              variable.parameter.cylc
+#    ^^       ^^                              variable.parameter.cylc
 
 """
 

--- a/tests/2.6-8_params.cylc
+++ b/tests/2.6-8_params.cylc
@@ -30,9 +30,14 @@ graph = """
 #            ^           ^^^ ^  variable.parameter.cylc
 #              ^                keyword.operator.assignment.cylc
 #                ^              constant.numeric.cylc
-#                           ^   punctuation.separator.parameter.cylc
-#                            ^  variable.parameter.cylc
 
+## With inter-cycle dependencies, qualifiers & optional output
+    a<b>[-P1]:c?
+#    ^^^         meta.annotation.parameterization.cylc
+#     ^          variable.parameter.cylc
+#       ^^^^^    meta.annotation.inter-cycle.cylc
+#            ^^  meta.annotation.qualifier.cylc
+#              ^ keyword.other.optional-output.cylc
 
 ## With Jinja
     foo<{{ a }}>

--- a/tests/2.9_graph_qualifiers.cylc
+++ b/tests/2.9_graph_qualifiers.cylc
@@ -4,6 +4,7 @@
 graph = """
 
     foo:fail
+#   ^^^      meta.variable.task.cylc
 #      ^     punctuation.definition.annotation.cylc
 #       ^^^^ variable.annotation.cylc
 #      ^^^^^ meta.annotation.qualifier.cylc
@@ -18,11 +19,5 @@ graph = """
 ## Not allowed without task
 :fail
 # <----- - meta.annotation.qualifier.cylc
-
-
-## With Jinja
-    {{ a }}:fail & foo:custom_{{ a }}
-#          ^^^^^                      meta.annotation.qualifier.cylc
-#                      ^^^^^^^        variable.annotation.cylc
 
 """


### PR DESCRIPTION
This is needed to allow the Textmate grammar to be added to GitHub Linguist. Currently:

> Invalid regex in grammar: `source.cylc` (in `Syntaxes/cylc.tmLanguage`) contains a malformed regex (regex "`(?<=(\b\w[\w\+\-@%]*|((:)([\w\-]`...": lookbehind assertion is not fixed length (at offset 43))

https://github.com/oliver-sanders/linguist/actions/runs/8569942718/job/23486858235#step:4:78

This unfortunately makes the grammar slightly less able to handle Jinja2 cropping up anywhere, but worth the tradeoff
