### PR TITLE
Fix `%include` and jinja2 not recognised inside graph section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ By making a contribution to this project, I certify that:
     the copyright and may be redistributed consistent with this project
     or the licence(s) involved.
 
-(e) I, or my employer, grant to NIWA and all recipients of
+(e) I, or my employer, grant to Earth Sciences New Zealand and all recipients of
     this software a perpetual, worldwide, non-exclusive, no-charge,
     royalty-free, irrevocable copyright licence to reproduce, modify,
     prepare derivative works of, publicly display, publicly perform,
@@ -74,7 +74,7 @@ By making a contribution to this project, I certify that:
     [Open Source Initiative (OSI)](http://www.opensource.org/).
 
 (f) If I become aware of anything that would make any of the above
-    inaccurate, in any way, I will let NIWA know as soon as
+    inaccurate, in any way, I will let Earth Sciences New Zealand know as soon as
     I become aware.
 
 (The Cylc Contributor Licence Agreement and Certificate of Origin is

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) NIWA & British Crown (Met Office) & Contributors.
+Copyright (c) Earth Sciences New Zealand & British Crown (Met Office) & Contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -26,4 +26,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This repository provides a TextMate grammar for Cylc workflow configuration (`su
 
 `cylc.tmLanguage.json` is the grammar file used by plugins for editors:
 - VSCode - [cylc/vscode-cylc](https://github.com/cylc/vscode-cylc)
-- Atom - [cylc/language-cylc](https://github.com/cylc/language-cylc)
 
 It is also used to build a TextMate bundle at [cylc/Cylc.tmLanguage](https://github.com/cylc/Cylc.tmbundle/) which is compatible with:
 - TextMate
@@ -20,7 +19,7 @@ If you're using an editor listed above, follow the link next to it for instructi
 
 ## Copyright and Terms of Use
 
-Copyright (C) 2008-<span actions:bind='current-year'>2026</span> NIWA & British Crown (Met Office) & Contributors.
+Copyright (C) 2008-<span actions:bind='current-year'>2026</span> Earth Sciences New Zealand & British Crown (Met Office) & Contributors.
 
 [![License](https://img.shields.io/github/license/cylc/cylc-textmate-grammar.svg?color=lightgrey)](https://github.com/cylc/cylc-textmate-grammar/blob/master/LICENSE)
 
@@ -44,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 If you are new to TextMate grammars, there are a number of resources to look at:
 - [TextMate manual - language grammars](https://macromates.com/manual/en/language_grammars)
 - [VSCode syntax highlight guide](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide)
-- [Atom flight manual - creating a legacy TextMate grammar](https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/)
+- [Atom flight manual - creating a legacy TextMate grammar](https://web.archive.org/web/20221215062546/https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/)
 
 ### Modifying the grammar
 
@@ -158,12 +157,14 @@ npm install
 ```
 
 #### Style tests
+
 To run ESLint for style testing JavaScript files:
 ```
 npm run lint
 ```
 
 #### Unit tests
+
 We're using [vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test) for testing the textmate grammar. Test files reside in the `/tests` directory. These are essentially Cylc workflow files that are annotated with comments. The comments detail what the expected scopes of the test line are. The comments are read in by vscode-tmgrammar-test and compared to the actual applied scopes. An example test might be:
 ```ini
     foo = bar

--- a/cylc.tmLanguage.json
+++ b/cylc.tmLanguage.json
@@ -145,6 +145,12 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "include": "#jinja2"
+                        },
+                        {
+                            "include": "#includeFiles"
                         }
                     ]
                 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,5 @@
 /* THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
-   Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+   Copyright (C) Earth Sciences New Zealand & British Crown (Met Office) & Contributors.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -1,5 +1,5 @@
 /* THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
-   Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+   Copyright (C) Earth Sciences New Zealand & British Crown (Met Office) & Contributors.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/cylc.tmLanguage.js
+++ b/src/cylc.tmLanguage.js
@@ -281,7 +281,9 @@ class GraphSection8 extends GraphSection7 {
                         2: {name: 'keyword.operator.assignment.cylc'},
                     },
                     patterns: inherit.patterns
-                }
+                },
+                {include: '#jinja2'},
+                {include: '#includeFiles'},
             ]
         };
     }

--- a/tests/1.4_includes.cylc
+++ b/tests/1.4_includes.cylc
@@ -18,5 +18,11 @@
 #   ^^^^^^^^         keyword.control.include.cylc
     %include foo {{ a }} bar
 #   ^^^^^^^^                 keyword.control.include.cylc
-#            ^^^             string.cylc
-#                        ^^^ string.cylc
+#            ^^^         ^^^ string.cylc
+
+## Inside a graph section
+[[scheduling]]
+    [[graph]]
+        %include bar
+#       ^^^^^^^^     keyword.control.include.cylc
+#       ^^^^^^^^^^^^ meta.include.cylc

--- a/tests/2.1_graph_tasks_deps.cylc
+++ b/tests/2.1_graph_tasks_deps.cylc
@@ -59,7 +59,7 @@
     foo:fail => bar<x=2>
 #   ^^^                  meta.variable.task.cylc
 #               ^^^      meta.variable.task.cylc
-    
+
 """
 # <--- meta.graph-syntax.quoted.triple.cylc string.quoted.triple.cylc punctuation.definition.string.end.cylc
 
@@ -85,10 +85,3 @@
 #   ^^^^^^^ - meta.graph-section.cylc
     foo => bar
 #   ^^^^^^^^^^ - meta.graph-section.cylc
-
-
-## With Jinja
-[[graph]]
-    {{ a }} = foo => bar
-#           ^            keyword.operator.assignment.cylc
-#             ^^^^^^^^^^ meta.graph-syntax.unquoted.cylc

--- a/tests/3.2-3_jinja.cylc
+++ b/tests/3.2-3_jinja.cylc
@@ -65,7 +65,15 @@ a = """
 #   ^^^^^^^ meta.embedded.block.jinja source.jinja
 """
 
-graph = """
+## Inside Cylc graph sections
+[scheduling]
+[[graph]]
+
+    {% for date in DATES %}
+#   ^^^^^^^^^^^^^^^^^^^^^^^ meta.graph-section.cylc meta.embedded.block.jinja source.jinja
+
+    R/P5D = """
+#   ^^^^^^^^^^^ meta.graph-section.cylc
     {{ a }}
 #   ^^^^^^^ meta.embedded.block.jinja source.jinja
 
@@ -88,12 +96,23 @@ graph = """
 #       ^^^^^^^          ^^^^^^^  meta.embedded.block.jinja source.jinja
 """
 
-[[graph]]
     {{ a }} = foo => bar
 #   ^^^^^^^              meta.embedded.block.jinja source.jinja
+#           ^            keyword.operator.assignment.cylc
+#             ^^^^^^^^^^ meta.graph-syntax.unquoted.cylc
 
 [scheduler]
 ## Inside a Cylc comment (it still gets executed at parse-time)
     # blah {% set x = 14 %} blah {{ x }}
 #   ^^^^^^^                ^^^^^^        comment.line.cylc
 #          ^^^^^^^^^^^^^^^^      ^^^^^^^ meta.embedded.block.jinja source.jinja
+[scheduling]
+[[graph]]
+    # {{ x }}
+#   ^^        comment.line.cylc
+#     ^^^^^^^ meta.embedded.block.jinja source.jinja
+    R6 = """
+        # {{ x }}
+#       ^^        comment.line.cylc
+#         ^^^^^^^ meta.embedded.block.jinja source.jinja
+    """


### PR DESCRIPTION
Closes #28

Used Copilot GPT-5.3-Codex agent to help quickly identify the fix and then improved on it from there and added tests

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
